### PR TITLE
Updated vercel.json to fix the deployment issue.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "buildCommand": "cd apps/web && npm run build",
-  "outputDirectory": "apps/web/.next",
-  "installCommand": "npm install",
-  "framework": "nextjs",
   "functions": {
-    "apps/web/pages/api/**/*.js": {
+    "pages/api/**/*.js": {
       "runtime": "@vercel/node"
     },
-    "apps/web/pages/api/**/*.ts": {
+    "pages/api/**/*.ts": {
       "runtime": "@vercel/node"
     }
   },


### PR DESCRIPTION
###  **Fix Vercel deployment configuration for monorepo**

###   Problem

  Deployment was failing with error:
  npm error No workspaces found: --workspace=apps/web
  sh: line 1: cd: apps/web: No such file or directory
  Error: Command "cd apps/web && npm run build" exited with 1
  
###   **Root Cause**

  The vercel.json configuration was conflicting with the "Root Directory" setting in Vercel dashboard. When root
  directory is set to apps/web, all paths in vercel.json should be relative to that directory, not the monorepo root.
  
###  **Solution**

- Removed problematic build commands that tried to navigate directories
- Updated function paths from apps/web/pages/api/**/*.js → pages/api/**/*.js (relative to root directory)
- Preserved essential functionality: API routes, NextAuth, URL rewrites
- Let Vercel auto-detect build process for better reliability

Happy to assist! 
@Nrentzilas 